### PR TITLE
add missing deps for `show_result.py`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ shortuuid
 tqdm
 gradio==3.40.0
 httpx==0.25.2
+plotly
+scikit-learn


### PR DESCRIPTION
`show_result.py` requires some deps (`plotly` and `scikit-learn`) that are missing in the `requirements.txt` file